### PR TITLE
Fix crash when reloading stylesheets for document with scripts in head

### DIFF
--- a/src/plugin/SolLuaDocument.cpp
+++ b/src/plugin/SolLuaDocument.cpp
@@ -29,6 +29,9 @@ namespace Rml::SolLua
 	{
 		auto* context = GetContext();
 
+		// A context isn't present in the case of reloading stylesheets which reprocesses the whole head section.
+		if (context == nullptr) return;
+
 		Rml::String buffer{ "--" };
 		buffer.append("[");
 		buffer.append(context->GetName());


### PR DESCRIPTION
When calling ReloadStyleSheet on a document RmlUi reprocesses the head section of the document in a disconnected copy so a context isn't present. If this head section also includes scripts these are also reprocessed causing LoadInlineScript in RmlSolLua to be called without a context present, without this check it causes a null pointer exception.