### PR TITLE
Move SolLuaDataModel constructor out-of-line

### DIFF
--- a/src/plugin/SolLuaDataModel.cpp
+++ b/src/plugin/SolLuaDataModel.cpp
@@ -5,6 +5,7 @@
 
 namespace Rml::SolLua
 {
+	SolLuaDataModel::SolLuaDataModel(sol::state_view s) : Lua{ s } {}
 
 	SolLuaObjectDef::SolLuaObjectDef(SolLuaDataModel* model)
 		: VariableDefinition(DataVariableType::Scalar), m_model(model)

--- a/src/plugin/SolLuaDataModel.h
+++ b/src/plugin/SolLuaDataModel.h
@@ -17,7 +17,7 @@ namespace Rml::SolLua
 
 	struct SolLuaDataModel
 	{
-		SolLuaDataModel(sol::state_view s) : Lua{ s } {}
+		SolLuaDataModel(sol::state_view s);
 
 		Rml::DataModelConstructor Constructor;
 		Rml::DataModelHandle Handle;


### PR DESCRIPTION
This is a trivial refactoring that enables C++23 builds with existing compilers.

In C++23 `std::unique_ptr` became `constexpr`, which made compilers instantiate its destructor more eagerly, which is problematic when pointee type is incomplete (`SolLuaObjectDef` in this case). Moving constructor definition to `.cpp` file removes the trigger for this behavior.

I'd like to note that I didn't test this change isolated in this repository, but I tested it integrated in one of the user's projects.