### PR TITLE
Make CMake target work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,14 @@ target_sources (RmlSolLua
 
 target_include_directories (RmlSolLua
 	PRIVATE
-		${PROJECT_SOURCE_DIR}src/
-		${PROJECT_SOURCE_DIR}include/
+		${PROJECT_SOURCE_DIR}/src/
 
 	PUBLIC
-		${PROJECT_SOURCE_DIR}include/
+		${PROJECT_SOURCE_DIR}/include/
+		${SOL_INCLUDE_DIR}
 )
+
+target_link_libraries(RmlSolLua PUBLIC RmlUi::Core)
 
 
 # TODO: Add tests and install targets if needed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project requires C++17.
 
 ```c++
 #include <RmlUi/RmlUi.h>
-#include <sol/sol.hpp>
+#include <sol.hpp>
 #include <RmlSolLua/RmlSolLua.h>
 
 int main()

--- a/src/RmlSolLua.cpp
+++ b/src/RmlSolLua.cpp
@@ -1,6 +1,6 @@
 ﻿#include "RmlSolLua/RmlSolLua.h"
 
-#include <sol/sol.hpp>
+#include <sol.hpp>
 #include <RmlUi/Core.h>
 
 #include "bind/bind.h"

--- a/src/bind/bind.h
+++ b/src/bind/bind.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <RmlUi/Core.h>
-#include <sol/sol.hpp>
+#include <sol.hpp>
 
 #include <type_traits>
 

--- a/src/plugin/SolLuaDataModel.h
+++ b/src/plugin/SolLuaDataModel.h
@@ -8,7 +8,7 @@
 #include <RmlUi/Core/Variant.h>
 #include <RmlUi/Core/DataTypes.h>
 
-#include <sol/sol.hpp>
+#include <sol.hpp>
 
 
 namespace Rml::SolLua

--- a/src/plugin/SolLuaDocument.h
+++ b/src/plugin/SolLuaDocument.h
@@ -2,7 +2,7 @@
 
 #include <RmlUi/Core/ElementDocument.h>
 
-#include <sol/sol.hpp>
+#include <sol.hpp>
 
 
 namespace Rml::SolLua

--- a/src/plugin/SolLuaEventListener.h
+++ b/src/plugin/SolLuaEventListener.h
@@ -2,7 +2,7 @@
 
 #include <RmlUi/Core/Types.h>
 #include <RmlUi/Core/EventListener.h>
-#include <sol/sol.hpp>
+#include <sol.hpp>
 
 
 namespace Rml

--- a/src/plugin/SolLuaInstancer.h
+++ b/src/plugin/SolLuaInstancer.h
@@ -3,7 +3,7 @@
 #include <RmlUi/Core/ElementInstancer.h>
 #include <RmlUi/Core/EventListenerInstancer.h>
 
-#include <sol/sol.hpp>
+#include <sol.hpp>
 
 
 namespace Rml::SolLua

--- a/src/plugin/SolLuaPlugin.h
+++ b/src/plugin/SolLuaPlugin.h
@@ -8,7 +8,7 @@
 #include <RmlUi/Lua/Header.h>
 #include <RmlUi/Core/Plugin.h>
 #include <RmlUi/Core/Platform.h>
-#include <sol/sol.hpp>
+#include <sol.hpp>
 
 #include <memory>
 


### PR DESCRIPTION
After #3 was merged (thank you!), I started integrating the latest version of this library into the project I'm working on. I found out that (a) CMake target doesn't work, and, more importantly, (b) the way sol is `#include`d makes it almost impossible to consume the library without patching. The way it used to work up until now in my project is that both issues were addressed by rather intrusive manual patches that are not upstreamable. This PR aims to rectify the situation, and make the library consumable as a CMake target.

Changes are:
1. Missing path separator was added to `target_include_directories`. Also, a duplicated entry was removed (`PUBLIC` implies `PRIVATE` and `INTERFACE`).
2. `#include <sol/sol.hpp>` was converted to `#include <sol.hpp>`.
3. `SOL_INCLUDE_DIR` variable is introduced and passed to `target_include_directories`.
4. `target_link_libraries(RmlSolLua PUBLIC RmlUi::Core)` was added.

Change 1 is what makes me think that `RmlSolLua` target was never used, because without path separators include paths are wrong, and nothing builds. Which means changes there shouldn't break anyone. What my project did is that they replaced the entirety of CMakeLists with a variable that holds paths to sources, and just adds them to their build.

Change 2 is the reason this PR even exists. While I can work around all the deficiencies of CMakeLists, patching the sources without trying to fix this upstream is going too far for me. A release of sol contains just 3 headers without any directory structure. Which means this library can't assume where those headers are. In my project, sol is placed into `sol2` directory instead of `sol`, so I would have to go to great lengths to pretend otherwise.

Instead of assuming where sol is placed, change 3 adds a customization point for users to say where their sol headers are.

Change 4 is there so that RmlUi include paths are passed to the compiler when RmlSolLua is built.