### PR TITLE
Fix external script loading in documents loaded from absolute paths

### DIFF
--- a/src/plugin/SolLuaDocument.cpp
+++ b/src/plugin/SolLuaDocument.cpp
@@ -53,7 +53,10 @@ namespace Rml::SolLua
 		if (!m_lua_env_identifier.empty())
 			m_environment[m_lua_env_identifier] = GetId();
 
-		m_state.safe_script_file(source_path, m_environment, ErrorHandler);
+		// Fix the path if a leading colon has been replaced with a pipe.
+		String fixed_path = StringUtilities::Replace(source_path, '|', ':');
+
+		m_state.safe_script_file(fixed_path, m_environment, ErrorHandler);
 	}
 
 	sol::protected_function_result SolLuaDocument::RunLuaScript(const Rml::String& script)


### PR DESCRIPTION
**Issue:** 
Documents loaded using absolute paths cannot load external scripts.
Drive separators ':' in absolute paths are internally replaced by pipes '|' to be url-compatible. Paths handed to LoadExternalScript by RmlUi still have this format, which results in an error when safe_script_file tries to open them.

**Solution:**
Replace the pipes with colons again before loading the script file.
This one line fix is copied from Rml::StreamFile::Open, where url-compatible paths are also converted back before being handed to the FileInterface.